### PR TITLE
Upgrade cops for Rubocop v1.x

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -177,7 +177,7 @@ Style/TernaryParentheses:
 # EnforcedColonStyle: key - left alignment of keys.
 #   a: 0
 #   bb: 1
-Layout/AlignHash:
+Layout/HashAlignment:
   EnforcedHashRocketStyle: key
   EnforcedColonStyle: key
 
@@ -188,7 +188,7 @@ Layout/AlignHash:
 #
 #     method_call(a,
 #       b)
-Layout/AlignParameters:
+Layout/ParameterAlignment:
   EnforcedStyle: with_fixed_indentation
 
 # Checks how the whens of a case expression are indented in relation to its end keyword.
@@ -250,7 +250,7 @@ Layout/FirstMethodParameterLineBreak:
 # and_in_a_method_call([
 #   :no_difference
 # ])
-Layout/IndentFirstArrayElement:
+Layout/FirstArrayElementIndentation:
   EnforcedStyle: consistent
 
 # Checks the indentation of the first key in a hash literal.
@@ -264,7 +264,7 @@ Layout/IndentFirstArrayElement:
 # and_in_a_method_call({
 #   no: :difference
 # })
-Layout/IndentFirstHashElement:
+Layout/FirstHashElementIndentation:
   EnforcedStyle: consistent
 
 # Checks that multiline assignments do not have a newline after the assignment operator.

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -382,3 +382,116 @@ Lint/AssignmentInCondition:
 # "result is #{10}"
 Lint/LiteralInInterpolation:
   AutoCorrect: true
+
+# Add new cops added since this was last updated
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: true
+
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+
+Lint/BinaryOperatorWithIdenticalOperands:
+  Enabled: true
+
+Lint/DeprecatedOpenSSLConstant:
+  Enabled: true
+
+Lint/DuplicateElsifCondition:
+  Enabled: true
+
+Lint/DuplicateRescueException:
+  Enabled: true
+
+Lint/EmptyConditionalBody:
+  Enabled: true
+
+Lint/FloatComparison:
+  Enabled: true
+
+Lint/MissingSuper:
+  Enabled: true
+
+Lint/MixedRegexpCaptureTypes:
+  Enabled: true
+
+Lint/OutOfRangeRegexpRef:
+  Enabled: true
+
+Lint/RaiseException:
+  Enabled: true
+
+Lint/SelfAssignment:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
+
+Lint/TopLevelReturnWithArgument:
+  Enabled: true
+
+Lint/UnreachableLoop:
+  Enabled: true
+
+Style/AccessorGrouping:
+  Enabled: true
+
+Style/ArrayCoercion:
+  Enabled: true
+
+Style/BisectedAttrAccessor:
+  Enabled: true
+
+Style/CaseLikeIf:
+  Enabled: true
+
+Style/ExplicitBlockArgument:
+  Enabled: true
+
+Style/ExponentialNotation:
+  Enabled: true
+
+Style/GlobalStdStream:
+  Enabled: true
+
+Style/HashAsLastArrayItem:
+  Enabled: true
+
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashLikeCase:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true
+
+Style/OptionalBooleanParameter:
+  Enabled: true
+
+Style/RedundantAssignment:
+  Enabled: true
+
+Style/RedundantFetchBlock:
+  Enabled: true
+
+Style/RedundantFileExtensionInRequire:
+  Enabled: true
+
+Style/RedundantRegexpCharacterClass:
+  Enabled: true
+
+Style/RedundantRegexpEscape:
+  Enabled: true
+
+Style/SingleArgumentDig:
+  Enabled: true
+
+Style/SlicingWithRange:
+  Enabled: true
+
+Style/StringConcatenation:
+  Enabled: true
+

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,3 @@
-# Up to date as of v0.54.0
 # If a cop is not referenced here, the defaults from Rubocop will be used.
 
 AllCops:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,7 +11,7 @@ AllCops:
   ExtraDetails: true
   UseCache: true
   MaxFilesInCache: 50000
-  TargetRubyVersion: 2.3
+  TargetRubyVersion: 2.4
   TargetRailsVersion: 4.2
 
 # Always use alias_method when aliasing methods of modules, classes, or singleton classes at runtime, as the lexical


### PR DESCRIPTION
Update existing cop names, and add new ones.

Update `TargetRubyVersion`
