### PR TITLE
Add config for rubocop 1.x compatible

### DIFF
--- a/.rubocop_1.x.yml
+++ b/.rubocop_1.x.yml
@@ -10,7 +10,7 @@ AllCops:
   ExtraDetails: true
   UseCache: true
   MaxFilesInCache: 50000
-  TargetRubyVersion: 2.6
+  TargetRubyVersion: 2.4
   TargetRailsVersion: 4.2
 
 # Always use alias_method when aliasing methods of modules, classes, or singleton classes at runtime, as the lexical

--- a/.rubocop_1.x.yml
+++ b/.rubocop_1.x.yml
@@ -13,6 +13,501 @@ AllCops:
   TargetRubyVersion: 2.4
   TargetRailsVersion: 4.2
 
+#################### Style ################################
+
+# This cop checks for grouping of accessors in `class` and `module`
+# bodies. By default it enforces accessors to be placed in grouped
+# declarations, but it can be configured to enforce separating them
+# in multiple declarations.
+#
+# NOTE: `Sorbet` is not compatible with “grouped” style. Consider “separated” style or disabling this cop.
+#
+#
+# EnforcedStyle: grouped (default)
+#
+# # bad
+# class Foo
+#   attr_reader :bar
+#   attr_reader :baz
+# end
+#
+# # good
+# class Foo
+#   attr_reader :bar, :baz
+# end
+Style/AccessorGrouping:
+  Enabled: true
+
+# This cop enforces the use of `Array()` instead of explicit `Array`
+# check or `[*var]`.
+#
+# The cop is disabled by default due to safety concerns.
+#
+# # bad
+# paths = [paths] unless paths.is_a?(Array)
+# paths.each { |path| do_something(path) }
+#
+# # bad (always creates a new Array instance)
+# [*paths].each { |path| do_something(path) }
+#
+# # good (and a bit more readable)
+# Array(paths).each { |path| do_something(path) }
+Style/ArrayCoercion:
+  Enabled: true
+
+# This cop checks for places where `attr_reader` and `attr_writer` for the same method can be combined into single `attr_accessor`.
+#
+# # bad
+# class Foo
+#   attr_reader :bar
+#   attr_writer :bar
+# end
+#
+# # good
+# class Foo
+#   attr_accessor :bar
+# end
+Style/BisectedAttrAccessor:
+  Enabled: true
+
+# This cop identifies places where `if-elsif` constructions can be replaced with `case-when`.
+#
+# # bad
+# if status == :active
+#   perform_action
+# elsif status == :inactive || status == :hibernating
+#   check_timeout
+# else
+#   final_action
+# end
+#
+# # good
+# case status
+# when :active
+#   perform_action
+# when :inactive, :hibernating
+#   check_timeout
+# else
+#   final_action
+# end
+Style/CaseLikeIf:
+  Enabled: true
+
+# This cop enforces the use of explicit block argument to avoid
+# writing block literal that just passes its arguments to another
+# block.
+#
+# NOTE: This cop only registers an offense if the block args match
+# the yield args exactly.
+#
+# # bad
+# def with_tmp_dir
+#   Dir.mktmpdir do |tmp_dir|
+#     Dir.chdir(tmp_dir) { |dir| yield dir } # block just passes arguments
+#   end
+# end
+#
+# # bad
+# def nine_times
+#   9.times { yield }
+# end
+#
+# # good
+# def with_tmp_dir(&block)
+#   Dir.mktmpdir do |tmp_dir|
+#     Dir.chdir(tmp_dir, &block)
+#   end
+# end
+#
+# with_tmp_dir do |dir|
+#   puts "dir is accessible as a parameter and pwd is set: #{dir}"
+# end
+#
+# # good
+# def nine_times(&block)
+#   9.times(&block)
+# end
+Style/ExplicitBlockArgument:
+  Enabled: true
+
+# This cop enforces consistency when using exponential notation for
+# numbers in the code (eg 1.2e4). Different styles are supported:
+#
+# `scientific` which enforces a mantissa between 1 (inclusive) and 10
+# (exclusive).
+#
+# `engineering` which enforces the exponent to be a multiple of 3 and
+# the mantissa to be between 0.1 (inclusive) and 10 (exclusive).
+#
+# `integral` which enforces the mantissa to always be a whole number
+# without trailing zeroes.
+#
+#
+# EnforcedStyle: scientific (default)
+#
+# # Enforces a mantissa between 1 (inclusive) and 10 (exclusive).
+#
+# # bad
+# 10e6
+# 0.3e4
+# 11.7e5
+# 3.14e0
+#
+# # good
+# 1e7
+# 3e3
+# 1.17e6
+# 3.14
+Style/ExponentialNotation:
+  Enabled: true
+
+# This cop enforces the use of `$stdout/$stderr/$stdin` instead of
+# `STDOUT/STDERR/STDIN`. `STDOUT/STDERR/STDIN` are constants, and
+# while you can actually reassign (possibly to redirect some stream)
+# constants in Ruby, you'll get an interpreter warning if you do so.
+#
+# # bad
+# STDOUT.puts('hello')
+#
+# hash = { out: STDOUT, key: value }
+#
+# def m(out = STDOUT)
+#   out.puts('hello')
+# end
+#
+# # good
+# $stdout.puts('hello')
+#
+# hash = { out: $stdout, key: value }
+#
+# def m(out = $stdout)
+#   out.puts('hello')
+# end
+Style/GlobalStdStream:
+  Enabled: true
+
+# Checks for presence or absence of braces around hash literal as a
+# last array item depending on configuration.
+#
+# NOTE: This cop will ignore arrays where all items are hashes,
+# regardless of EnforcedStyle.
+#
+# EnforcedStyle: braces (default)
+#
+# # bad
+# [1, 2, one: 1, two: 2]
+#
+# # good
+# [1, 2, { one: 1, two: 2 }]
+#
+# # good
+# [{ one: 1 }, { two: 2 }]
+Style/HashAsLastArrayItem:
+  Enabled: true
+
+# This cop checks for uses of `each_key` and `each_value` Hash
+# methods.
+#
+# NOTE: If you have an array of two-element arrays, you can put
+#
+# ```
+# parentheses around the block arguments to indicate that you're not
+# working with a hash, and suppress RuboCop offenses.
+# ```
+#
+# # bad
+# hash.keys.each { |k| p k }
+# hash.values.each { |v| p v }
+#
+# # good
+# hash.each_key { |k| p k }
+# hash.each_value { |v| p v }
+Style/HashEachMethods:
+  Enabled: true
+
+# This cop checks for places where `case-when` represents a simple
+# 1:1 mapping and can be replaced with a hash lookup.
+#
+# MinBranchesCount: 3 (default)
+#
+# # bad
+# case country
+# when 'europe'
+#   'http://eu.example.com'
+# when 'america'
+#   'http://us.example.com'
+# when 'australia'
+#   'http://au.example.com'
+# end
+#
+# # good
+# SITES = {
+#   'europe'    => 'http://eu.example.com',
+#   'america'   => 'http://us.example.com',
+#   'australia' => 'http://au.example.com'
+# }
+# SITES[country]
+Style/HashLikeCase:
+  Enabled: true
+
+# This cop looks for uses of
+# `_.each_with_object({}) …`, `_.map ….to_h`, and `Hash[_.map …]`
+# that are actually just transforming the keys of a hash, and tries
+# to use a simpler & faster call to `transform_keys` instead.
+#
+# # bad
+# {a: 1, b: 2}.each_with_object({}) { |(k, v), h| h[foo(k)] = v }
+# Hash[{a: 1, b: 2}.collect { |k, v| [foo(k), v] }]
+# {a: 1, b: 2}.map { |k, v| [k.to_s, v] }.to_h
+# {a: 1, b: 2}.to_h { |k, v| [k.to_s, v] }
+#
+# # good
+# {a: 1, b: 2}.transform_keys { |k| foo(k) }
+# {a: 1, b: 2}.transform_keys { |k| k.to_s }
+Style/HashTransformKeys:
+  Enabled: true
+
+# This cop looks for uses of
+# `_.each_with_object({}) …`, `_.map ….to_h`, and `Hash[_.map …]`
+# that are actually just transforming the values of a hash, and tries
+# to use a simpler & faster call to `transform_values` instead.
+#
+# # bad
+# {a: 1, b: 2}.each_with_object({}) { |(k, v), h| h[k] = foo(v) }
+# Hash[{a: 1, b: 2}.collect { |k, v| [k, foo(v)] }]
+# {a: 1, b: 2}.map { |k, v| [k, v * v] }.to_h
+# {a: 1, b: 2}.to_h { |k, v| [k, v * v] }
+#
+# # good
+# {a: 1, b: 2}.transform_values { |v| foo(v) }
+# {a: 1, b: 2}.transform_values { |v| v * v }
+Style/HashTransformValues:
+  Enabled: true
+
+# This cop checks for places where keyword arguments can be used
+# instead of boolean arguments when defining methods.
+# `respond_to_missing?` method is allowed by default. These are
+# customizable with `AllowedMethods` option.
+#
+# # bad
+# def some_method(bar = false)
+#   puts bar
+# end
+#
+# # bad - common hack before keyword args were introduced
+# def some_method(options = {})
+#   bar = options.fetch(:bar, false)
+#   puts bar
+# end
+#
+# # good
+# def some_method(bar: false)
+#   puts bar
+# end
+Style/OptionalBooleanParameter:
+  Enabled: true
+
+# This cop checks for redundant assignment before returning.
+#
+# # bad
+# def test
+#   x = foo
+#   x
+# end
+#
+# # bad
+# def test
+#   if x
+#     z = foo
+#     z
+#   elsif y
+#     z = bar
+#     z
+#   end
+# end
+#
+# # good
+# def test
+#   foo
+# end
+#
+# # good
+# def test
+#   if x
+#     foo
+#   elsif y
+#     bar
+#   end
+# end
+Style/RedundantAssignment:
+  Enabled: true
+
+# This cop identifies places where `fetch(key) { value }` can be replaced by `fetch(key, value)`.
+#
+# In such cases `fetch(key, value)` method is faster than `fetch(key) { value }`.
+#
+# SafeForConstants: true
+# # bad
+# ENV.fetch(:key) { VALUE }
+#
+# # good
+# ENV.fetch(:key, VALUE)
+Style/RedundantFetchBlock:
+  Enabled: true
+
+# This cop checks for the presence of superfluous `.rb` extension in the filename provided to `require` and `require_relative`.
+#
+# Note: If the extension is omitted, Ruby tries adding '.rb', '.so',
+#
+# ```
+# and so on to the name until found. If the file named cannot be found,
+# a `LoadError` will be raised.
+# There is an edge case where `foo.so` file is loaded instead of a `LoadError`
+# if `foo.so` file exists when `require 'foo.rb'` will be changed to `require 'foo'`,
+# but that seems harmless.
+# ```
+#
+# # bad
+# require 'foo.rb'
+# require_relative '../foo.rb'
+#
+# # good
+# require 'foo'
+# require 'foo.so'
+# require_relative '../foo'
+# require_relative '../foo.so'
+Style/RedundantFileExtensionInRequire:
+  Enabled: true
+
+# This cop checks for unnecessary single-element Regexp character classes.
+#
+# # bad
+# r = /[x]/
+#
+# # good
+# r = /x/
+#
+# # bad
+# r = /[\s]/
+#
+# # good
+# r = /\s/
+#
+# # bad
+# r = %r{/[b]}
+#
+# # good
+# r = %r{/b}
+#
+# # good
+# r = /[ab]/
+Style/RedundantRegexpCharacterClass:
+  Enabled: true
+
+# This cop checks for redundant escapes inside Regexp literals.
+#
+# # bad
+# %r{foo\/bar}
+#
+# # good
+# %r{foo/bar}
+#
+# # good
+# /foo\/bar/
+#
+# # good
+# %r/foo\/bar/
+#
+# # good
+# %r!foo\!bar!
+#
+# # bad
+# /a\-b/
+#
+# # good
+# /a-b/
+#
+# # bad
+# /[\+\-]\d/
+#
+# # good
+# /[+\-]\d/
+Style/RedundantRegexpEscape:
+  Enabled: true
+
+# Sometimes using dig method ends up with just a single argument.
+# In such cases, dig should be replaced with [].
+#
+# # bad
+# { key: 'value' }.dig(:key)
+# [1, 2, 3].dig(0)
+#
+# # good
+# { key: 'value' }[:key]
+# [1, 2, 3][0]
+#
+# # good
+# { key1: { key2: 'value' } }.dig(:key1, :key2)
+# [1, [2, [3]]].dig(1, 1)
+#
+# # good
+# keys = %i[key1 key2]
+# { key1: { key2: 'value' } }.dig(*keys)
+Style/SingleArgumentDig:
+  Enabled: true
+
+# This cop checks that arrays are sliced with endless ranges instead of `ary` on Ruby 2.6+.
+#
+# # bad
+# items[1..-1]
+#
+# # good
+# items[1..]
+Style/SlicingWithRange:
+  Enabled: true
+
+# This cop checks for places where string concatenation can be
+# replaced with string interpolation.
+#
+# The cop can autocorrect simple cases but will skip autocorrecting
+# more complex cases where the resulting code would be harder to
+# read. In those cases, it might be useful to extract statements to
+# local variables or methods which you can then interpolate in a
+# string.
+#
+# NOTE: When concatenation between two strings is broken over multiple
+# lines, this cop does not register an offense; instead,
+# `Style/LineEndConcatenation` will pick up the offense if enabled.
+#
+# Two modes are supported:
+#
+# `aggressive` style checks and corrects all occurrences of `+` where
+#
+# either the left or right side of `+` is a string literal.
+#
+# `conservative` style on the other hand, checks and corrects only if
+#
+# left side (receiver of `+` method call) is a string literal. This
+# is useful when the receiver is some expression that returns string
+# like `Pathname` instead of a string literal.
+#
+#
+# Mode: aggressive (default)
+# # bad
+# email_with_name = user.name + ' <' + user.email + '>'
+# Pathname.new('/') + 'test'
+#
+# # good
+# email_with_name = "#{user.name} <#{user.email}>"
+# email_with_name = format('%s <%s>', user.name, user.email)
+# "#{Pathname.new('/')}test"
+#
+# # accepted, line-end concatenation
+# name = 'First' +
+#   'Last'
+Style/StringConcatenation:
+  Enabled: true
+
 # Always use alias_method when aliasing methods of modules, classes, or singleton classes at runtime, as the lexical
 # scope of alias leads to unpredictability in these cases.
 Style/Alias:
@@ -166,6 +661,74 @@ Style/TernaryParentheses:
   EnforcedStyle: require_parentheses_when_complex
 
 #################### Layout ################################
+
+# Checks for a newline after an attribute accessor or a group of them
+# . `alias` syntax and `alias_method`, `public`, `protected`, and
+# `private` methods are allowed by default. These are customizable
+# with `AllowAliasSyntax` and `AllowedMethods` options.
+#
+# # bad
+# attr_accessor :foo
+# def do_something
+# end
+#
+# # good
+# attr_accessor :foo
+#
+# def do_something
+# end
+#
+# # good
+# attr_accessor :foo
+# attr_reader :bar
+# attr_writer :baz
+# attr :qux
+#
+# def do_something
+# end
+#
+# AllowAliasSyntax: true (default)
+#
+# # good
+# attr_accessor :foo
+# alias :foo? :foo
+#
+# def do_something
+# end
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: true
+
+# Checks method call operators to not have spaces around them.
+#
+# # bad
+# foo. bar
+# foo .bar
+# foo . bar
+# foo. bar .buzz
+# foo
+#   . bar
+#   . buzz
+# foo&. bar
+# foo &.bar
+# foo &. bar
+# foo &. bar&. buzz
+# RuboCop:: Cop
+# RuboCop:: Cop:: Cop
+# :: RuboCop::Cop
+#
+# # good
+# foo.bar
+# foo.bar.buzz
+# foo
+#   .bar
+#   .buzz
+# foo&.bar
+# foo&.bar&.buzz
+# RuboCop::Cop
+# RuboCop::Cop::Cop
+# ::RuboCop::Cop
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
 
 # Align the elements of a hash literal if they span more than one line.
 #
@@ -382,115 +945,376 @@ Lint/AssignmentInCondition:
 Lint/LiteralInInterpolation:
   AutoCorrect: true
 
-# Add new cops added since this was last updated
-Layout/EmptyLinesAroundAttributeAccessor:
-  Enabled: true
-
-Layout/SpaceAroundMethodCallOperator:
-  Enabled: true
-
+# This cop checks for places where binary operator has identical
+# operands.
+# It covers arithmetic operators: `-`, `/`, `%`;
+# comparison operators: `==`, `===`, `=~`, `>`, `>=`, `<`, `<=`;
+# bitwise operators: `|`, `^`, `&`;
+# boolean operators: `&&`, `||` and “spaceship” operator - `<=>`.
+#
+# Simple arithmetic operations are allowed by this cop: `+`, `*`,
+# `**`, `<<` and `>>`. Although these can be rewritten in a
+# different way, it should not be necessary to do so. This does not
+# include operations such as `-` or `/` where the result will always
+# be the same (`x - x` will always be 0; `x / x` will always be 1),
+# and thus are legitimate offenses.
+#
+# bad
+# x / x
+# x.top >= x.top
+#
+# if a.x != 0 && a.x != 0
+#   do_something
+# end
+#
+# def child?
+#   left_child || left_child
+# end
+#
+# # good
+# x + x
+# 1 << 1
 Lint/BinaryOperatorWithIdenticalOperands:
   Enabled: true
 
+# Algorithmic constants for `OpenSSL::Cipher` and `OpenSSL::Digest`
+# deprecated since OpenSSL version 2.2.0. Prefer passing a string
+# instead.
+#
+# # Example for OpenSSL::Cipher instantiation.
+#
+# # bad
+# OpenSSL::Cipher::AES.new(128, :GCM)
+#
+# # good
+# OpenSSL::Cipher.new('aes-128-gcm')
+#
+# # Example for OpenSSL::Digest instantiation.
+#
+# # bad
+# OpenSSL::Digest::SHA256.new
+#
+# # good
+# OpenSSL::Digest.new('SHA256')
+#
+# # Example for ::Digest inherited class methods.
+#
+# # bad
+# OpenSSL::Digest::SHA256.digest('foo')
+#
+# # good
+# OpenSSL::Digest.digest('SHA256', 'foo')
 Lint/DeprecatedOpenSSLConstant:
   Enabled: true
 
+# This cop checks that there are no repeated conditions used in if 'elsif'.
+#
+# # bad
+# if x == 1
+#   do_something
+# elsif x == 1
+#   do_something_else
+# end
+#
+# # good
+# if x == 1
+#   do_something
+# elsif x == 2
+#   do_something_else
+# end
 Lint/DuplicateElsifCondition:
   Enabled: true
 
+# This cop checks that there are no repeated exceptions used in 'rescue' expressions.
+#
+# # bad
+# begin
+#   something
+# rescue FirstException
+#   handle_exception
+# rescue FirstException
+#   handle_other_exception
+# end
+#
+# # good
+# begin
+#   something
+# rescue FirstException
+#   handle_exception
+# rescue SecondException
+#   handle_other_exception
+# end
 Lint/DuplicateRescueException:
   Enabled: true
 
+# This cop checks for the presence of `if`, `elsif` and `unless` branches without a body.
+#
+# # bad
+# if condition
+# end
+#
+# # bad
+# unless condition
+# end
+#
+# # bad
+# if condition
+#   do_something
+# elsif other_condition
+# end
+#
+# # good
+# if condition
+#   do_something
+# end
+#
+# # good
+# unless condition
+#   do_something
+# end
+#
+# # good
+# if condition
+#   do_something
+# elsif other_condition
+#   do_something_else
+# end
 Lint/EmptyConditionalBody:
   Enabled: true
 
+# This cop checks for the presence of precise comparison of floating
+# point numbers.
+#
+# Floating point values are inherently inaccurate, and comparing
+# them for exact equality is almost never the desired semantics.
+# Comparison via the `==/!=` operators checks floating-point value
+# representation to be exactly the same, which is very unlikely if
+# you perform any arithmetic operations involving precision loss.
+#
+# # bad
+# x == 0.1
+# x != 0.1
+#
+# # good - using BigDecimal
+# x.to_d == 0.1.to_d
+#
+# # good
+# (x - 0.1).abs < Float::EPSILON
+#
+# # good
+# tolerance = 0.0001
+# (x - 0.1).abs < tolerance
+#
+# # Or some other epsilon based type of comparison:
+# # https://www.embeddeduse.com/2019/08/26/qt-compare-two-floats/
 Lint/FloatComparison:
   Enabled: true
 
+# This cop checks for the presence of constructors and lifecycle
+# callbacks without calls to `super`.
+#
+# This cop does not consider `method_missing` (and
+# `respond_to_missing?`) because in some cases it makes sense to
+# overtake what is considered a missing method. In other cases, the
+# theoretical ideal handling could be challenging or verbose for no
+# actual gain.
+#
+# # bad
+# class Employee < Person
+#   def initialize(name, salary)
+#     @salary = salary
+#   end
+# end
+#
+# # good
+# class Employee < Person
+#   def initialize(name, salary)
+#     super(name)
+#     @salary = salary
+#   end
+# end
+#
+# # bad
+# class Parent
+#   def self.inherited(base)
+#     do_something
+#   end
+# end
+#
+# # good
+# class Parent
+#   def self.inherited(base)
+#     super
+#     do_something
+#   end
+# end
 Lint/MissingSuper:
   Enabled: true
 
+# Do not mix named captures and numbered captures in a Regexp literal
+# because numbered capture is ignored if they're mixed. Replace
+# numbered captures with non-capturing groupings or named captures.
+#
+# # bad
+# /(?<foo>FOO)(BAR)/
+#
+# # good
+# /(?<foo>FOO)(?<bar>BAR)/
+#
+# # good
+# /(?<foo>FOO)(?:BAR)/
+#
+# # good
+# /(FOO)(BAR)/
 Lint/MixedRegexpCaptureTypes:
   Enabled: true
 
+# This cops looks for references of Regexp captures that are out of range and thus always returns nil.
+#
+#
+# /(foo)bar/ =~ 'foobar'
+#
+# # bad - always returns nil
+#
+# puts $2 # => nil
+#
+# # good
+#
+# puts $1 # => foo
 Lint/OutOfRangeRegexpRef:
   Enabled: true
 
+# This cop checks for `raise` or `fail` statements which are raising
+# `Exception` class.
+#
+# You can specify a module name that will be an implicit namespace
+# using `AllowedImplicitNamespaces` option. The cop cause a false
+# positive for namespaced `Exception` when a namespace is omitted.
+# This option can prevent the false positive by specifying a namespace
+# to be omitted for `Exception`. Alternatively, make `Exception` a
+# fully qualified class name with an explicit namespace.
+#
+# # bad
+# raise Exception, 'Error message here'
+#
+# # good
+# raise StandardError, 'Error message here'
 Lint/RaiseException:
   Enabled: true
 
+# This cop checks for self-assignments.
+#
+# # bad
+# foo = foo
+# foo, bar = foo, bar
+# Foo = Foo
+#
+# # good
+# foo = bar
+# foo, bar = bar, foo
+# Foo = Bar
 Lint/SelfAssignment:
   Enabled: true
 
+# This cop checks unexpected overrides of the `Struct` built-in methods via `Struct.new`.
+#
+# # bad
+# Bad = Struct.new(:members, :clone, :count)
+# b = Bad.new([], true, 1)
+# b.members #=> [] (overriding `Struct#members`)
+# b.clone #=> true (overriding `Object#clone`)
+# b.count #=> 1 (overriding `Enumerable#count`)
+#
+# # good
+# Good = Struct.new(:id, :name)
+# g = Good.new(1, "foo")
+# g.members #=> [:id, :name]
+# g.clone #=> #<struct Good id=1, name="foo">
+# g.count #=> 2
 Lint/StructNewOverride:
   Enabled: true
 
+# This cop checks for top level return with arguments. If there is a
+# top-level return statement with an argument, then the argument is
+# always ignored. This is detected automatically since Ruby 2.7.
+#
+# Detected since Ruby 2.7
+# return 1 # 1 is always ignored.
 Lint/TopLevelReturnWithArgument:
   Enabled: true
 
+# This cop checks for loops that will have at most one iteration.
+#
+# A loop that can never reach the second iteration is a possible error in the code. In rare cases where only one iteration (or at most one iteration) is intended behavior, the code should be refactored to use `if` conditionals.
+#
+# NOTE: Block methods that are used with `Enumerable`s are considered to be loops.
+#
+# `IgnoredPatterns` can be used to match against the block receiver
+# in order to allow code that would otherwise be registered as an
+# offense (eg. `times` used not in an `Enumerable` context).
+#
+# # bad
+# while node
+#   do_something(node)
+#   node = node.parent
+#   break
+# end
+#
+# # good
+# while node
+#   do_something(node)
+#   node = node.parent
+# end
+#
+# # bad
+# def verify_list(head)
+#   item = head
+#   begin
+#     if verify(item)
+#       return true
+#     else
+#       return false
+#     end
+#   end while(item)
+# end
+#
+# # good
+# def verify_list(head)
+#   item = head
+#   begin
+#     if verify(item)
+#       item = item.next
+#     else
+#       return false
+#     end
+#   end while(item)
+#
+#   true
+# end
+#
+# # bad
+# def find_something(items)
+#   items.each do |item|
+#     if something?(item)
+#       return item
+#     else
+#       raise NotFoundError
+#     end
+#   end
+# end
+#
+# # good
+# def find_something(items)
+#   items.each do |item|
+#     if something?(item)
+#       return item
+#     end
+#   end
+#   raise NotFoundError
+# end
+#
+# # bad
+# 2.times { raise ArgumentError }
 Lint/UnreachableLoop:
-  Enabled: true
-
-Style/AccessorGrouping:
-  Enabled: true
-
-Style/ArrayCoercion:
-  Enabled: true
-
-Style/BisectedAttrAccessor:
-  Enabled: true
-
-Style/CaseLikeIf:
-  Enabled: true
-
-Style/ExplicitBlockArgument:
-  Enabled: true
-
-Style/ExponentialNotation:
-  Enabled: true
-
-Style/GlobalStdStream:
-  Enabled: true
-
-Style/HashAsLastArrayItem:
-  Enabled: true
-
-Style/HashEachMethods:
-  Enabled: true
-
-Style/HashLikeCase:
-  Enabled: true
-
-Style/HashTransformKeys:
-  Enabled: true
-
-Style/HashTransformValues:
-  Enabled: true
-
-Style/OptionalBooleanParameter:
-  Enabled: true
-
-Style/RedundantAssignment:
-  Enabled: true
-
-Style/RedundantFetchBlock:
-  Enabled: true
-
-Style/RedundantFileExtensionInRequire:
-  Enabled: true
-
-Style/RedundantRegexpCharacterClass:
-  Enabled: true
-
-Style/RedundantRegexpEscape:
-  Enabled: true
-
-Style/SingleArgumentDig:
-  Enabled: true
-
-Style/SlicingWithRange:
-  Enabled: true
-
-Style/StringConcatenation:
   Enabled: true
 

--- a/.rubocop_1.x.yml
+++ b/.rubocop_1.x.yml
@@ -1,0 +1,496 @@
+# If a cop is not referenced here, the defaults from Rubocop will be used.
+
+AllCops:
+  Exclude:
+    - '**/db/**/*'
+    - '**/tmp/**/*'
+    - '**/vendor/**/*'
+    - '**/script/**/*'
+  DisplayStyleGuide: true
+  ExtraDetails: true
+  UseCache: true
+  MaxFilesInCache: 50000
+  TargetRubyVersion: 2.6
+  TargetRailsVersion: 4.2
+
+# Always use alias_method when aliasing methods of modules, classes, or singleton classes at runtime, as the lexical
+# scope of alias leads to unpredictability in these cases.
+Style/Alias:
+  EnforcedStyle: prefer_alias_method
+
+# Checks for cases when you could use a block accepting version of a method that does automatic resource cleanup.
+#
+#   # bad
+#   f = File.open('file')
+#
+#   # good
+#   f = File.open('file') do
+#     ...
+#   end
+Style/AutoResourceCleanup:
+  Enabled: true
+
+# Checks if usage of %() or %Q() matches configuration.
+#
+# EnforcedStyle: percent_q - enforces use of %Q().
+Style/BarePercentLiterals:
+  EnforcedStyle: percent_q
+
+# Checks the style of children definitions at classes and modules. Basically there are two different styles:
+#
+# EnforcedStyle:
+#   nested - have each child on its own line
+#     class Foo
+#       class Bar
+#       end
+#     end
+#
+# compact (allowed for specs only) - combine definitions as much as possible
+#   class Foo::Bar
+#   end
+Style/ClassAndModuleChildren:
+  Exclude:
+    - '**/spec/**/*'
+
+# Mapping from undesired method to desired method e.g. to use `detect` over `find`.
+Style/CollectionMethods:
+  Enabled: true
+  PreferredMethods:
+    collect: 'map'
+    collect!: 'map!'
+    inject: 'reduce'
+    detect: 'detect'
+    find_all: 'select'
+
+# This cop checks for missing top-level documentation of classes and modules. Classes with no body are exempt from the
+# check and so are namespace modules - modules that have nothing in their bodies except classes, other modules, or
+# constant definitions.
+#
+# The documentation requirement is annulled if the class or module has a "#:nodoc:" comment next to it. Likewise,
+# "#:nodoc: all" does the same for all its children.
+Style/Documentation:
+  Exclude:
+    - '**/spec/**/*'
+
+# Warn on empty else statements
+#
+# EnforcedStyle: empty - only return an error for a completely empty else clause as sometimes it may be necessary to
+# return `nil` from an else branch.
+Style/EmptyElse:
+  EnforcedStyle: empty
+
+# Checks for the formatting of empty method definitions.
+#
+# EnforcedStyle: expanded - only return an error if the end is on the same line as the def.
+#
+# bad
+# def foo(bar); end
+#
+# good
+# def foo(bar)
+# end
+Style/EmptyMethod:
+  EnforcedStyle: expanded
+  Exclude:
+    - '**/spec/**/*'
+
+# Checks for methods called on a do...end block. The point of this check is that it's easy to miss the call tacked on
+# to the block when reading code.
+Style/MethodCalledOnDoEndBlock:
+  Enabled: true
+
+# Checks for `if` / `case` expressions that do not have an `else` branch.
+#
+# Only configured to check for `case` statements. It's best practice to always provide a default for `case` statements.
+Style/MissingElse:
+  Enabled: true
+  EnforcedStyle: case
+
+# Use `next` to skip iteration instead of a condition at the end.
+#
+# # bad
+# [1, 2].each do |a|
+#   if a == 1 do
+#     puts a
+#   end
+# end
+#
+# # good
+# [1, 2].each do |a|
+#   next unless a == 1
+#
+#   puts a
+# end
+Style/Next:
+  EnforcedStyle: always
+
+# Checks for options hashes and discourages them if the current Ruby version supports keyword arguments.
+Style/OptionHash:
+  Enabled: true
+
+Style/PercentLiteralDelimiters:
+  PreferredDelimiters:
+    default: ()
+    '%i': '()'
+    '%I': '()'
+    '%w': '()'
+    '%W': '()'
+
+# Checks for the use of the send method. Prefers use of `__send__` and `public_send` over `send`.
+Style/Send:
+  Enabled: true
+
+# Enforces the use of consistent method names from the String class. So far it enforces use of `to_sym` over `intern`.
+Style/StringMethods:
+  Enabled: true
+
+# Check for array literals made up of symbols that are not using the %i() syntax.
+Style/SymbolArray:
+  Enabled: true
+  EnforcedStyle: brackets
+
+# Checks for the presence of parentheses around ternary conditions.
+#
+# EnforcedStyle: require_parentheses_when_complex
+#
+# bad
+# foo = (bar?) ? a : b
+# foo = (bar.baz?) ? a : b
+# foo = bar && baz ? a : b
+#
+# good
+# foo = bar? ? a : b
+# foo = bar.baz ? a : b
+# foo = (bar && baz) ? a : b
+Style/TernaryParentheses:
+  EnforcedStyle: require_parentheses_when_complex
+
+#################### Layout ################################
+
+# Align the elements of a hash literal if they span more than one line.
+#
+# EnforcedHashRocketStyle: key - left alignment of keys.
+#   'a' => 2
+#   'bb' => 3
+#
+# EnforcedColonStyle: key - left alignment of keys.
+#   a: 0
+#   bb: 1
+Layout/HashAlignment:
+  EnforcedHashRocketStyle: key
+  EnforcedColonStyle: key
+
+# Alignment of parameters in multi-line method calls.
+#
+# The `with_fixed_indentation` style aligns the following lines with one level of indentation relative to the start of
+# the line with the method call.
+#
+#     method_call(a,
+#       b)
+Layout/ParameterAlignment:
+  EnforcedStyle: with_fixed_indentation
+
+# Checks how the whens of a case expression are indented in relation to its end keyword.
+#
+# EnforcedStyle: end
+#
+# good
+# kind = case year
+# when 1850..1889
+#   'Blues'
+# when 1890..1909
+#   'Ragtime'
+# when 1910..1929
+#   'New Orleans Jazz'
+# when 1930..1939
+#   'Swing'
+# when 1940..1950
+#   'Bebop'
+# else
+#   'Jazz'
+# end
+Layout/CaseIndentation:
+  EnforcedStyle: end
+
+# Checks whether the end keywords are aligned properly.
+#
+# AlignWith: variable - in assignments, `end` should be aligned with the start of the variable on the left hand side of
+# `=`. In all other situations, `end` should still be aligned with the keyword.
+#
+# variable = if true
+# end
+Layout/EndAlignment:
+  EnforcedStyleAlignWith: variable
+
+# Checks for a line break before the first element in a multi-line array.
+Layout/FirstArrayElementLineBreak:
+  Enabled: true
+
+# Checks for a line break before the first element in a multi-line hash.
+Layout/FirstHashElementLineBreak:
+  Enabled: true
+
+# Checks for a line break before the first argument in a multi-line method call.
+Layout/FirstMethodArgumentLineBreak:
+  Enabled: true
+
+# Checks for a line break before the first parameter in a multi-line method parameter definition.
+Layout/FirstMethodParameterLineBreak:
+  Enabled: true
+
+# Checks the indentation of the first element in an array literal.
+#
+# The value `consistent` means that the indentation of the first element shall always be relative to the first position
+# of the line where the opening bracket is.
+#
+# array = [
+#   :value
+# ]
+# and_in_a_method_call([
+#   :no_difference
+# ])
+Layout/FirstArrayElementIndentation:
+  EnforcedStyle: consistent
+
+# Checks the indentation of the first key in a hash literal.
+#
+# The value `consistent` means that the indentation of the first key shall always be relative to the first position
+# of the line where the opening brace is.
+#
+# hash = {
+#   key: :value
+# }
+# and_in_a_method_call({
+#   no: :difference
+# })
+Layout/FirstHashElementIndentation:
+  EnforcedStyle: consistent
+
+# Checks that multiline assignments do not have a newline after the assignment operator.
+#
+# EnforcedStyle: same_line
+#
+# foo = if expression
+#   'bar'
+# end
+Layout/MultilineAssignmentLayout:
+  Enabled: true
+  EnforcedStyle: same_line
+
+# Checks the indentation of the method name part in method calls that span more than one line.
+#
+# EnforcedStyle: indented
+#
+# Thing.a
+#   .b
+#   .c
+Layout/MultilineMethodCallIndentation:
+  EnforcedStyle: indented
+
+# Checks the indentation of the right hand side operand in binary operations that span more than one line.
+#
+# EnforcedStyle: indented
+#
+# if a &&
+#     b
+#   something
+# end
+Layout/MultilineOperationIndentation:
+  EnforcedStyle: indented
+
+#################### Naming ##########################
+
+# Checks that all numbered variables use the configured style for their numbering.
+#
+# EnforcedStyle: snake_case
+#
+# # bad
+#
+# variable1 = 1
+#
+# # good
+#
+# variable_1 = 1
+Naming/VariableNumber:
+  EnforcedStyle: snake_case
+
+#################### Metrics ################################
+
+# Checks that the ABC size of methods is not higher than the configured maximum. The ABC size is based on assignments,
+# branches (method calls), and conditions. See http://c2.com/cgi/wiki?AbcMetric.
+Metrics/AbcSize:
+  Max: 22
+
+# This cop checks if the length of a block exceeds some maximum value. Ignores comment-only lines.
+Metrics/BlockLength:
+  Exclude:
+    - '**/routes.rb'
+    - '**/config/initializers/**/*.rb'
+    - '**/config/environments/**/*.rb'
+    - '**/spec/**/*'
+    - '**/*.gemspec'
+
+# Checks if the length a class exceeds some maximum value. Ignores comment-only lines.
+Metrics/ClassLength:
+  Max: 150
+
+# Checks that the cyclomatic complexity of methods is not higher than the configured maximum. The cyclomatic complexity
+# is the number of linearly independent paths through a method. The algorithm counts decision points and adds one.
+#
+# An if statement (or unless or ?:) increases the complexity by one. An else branch does not, since it doesn't add a
+# decision point. The && operator (or keyword and) can be converted to a nested if statement, and ||/or is shorthand for
+# a sequence of ifs, so they also add one. Loops can be said to have an exit condition, so they add one.
+Metrics/CyclomaticComplexity:
+  Max: 10
+
+# Checks the length of lines in the source code.
+Metrics/LineLength:
+  Max: 120
+  Exclude:
+    - '**/routes.rb'
+    - '**/config/initializers/**/*.rb'
+    - '**/config/environments/**/*.rb'
+    - '**/Gemfile'
+
+# Checks if the length of a method exceeds some maximum value. Ignores comment-only lines.
+Metrics/MethodLength:
+  Max: 20
+  Exclude:
+    - '**/spec/**/*'
+
+# Checks if the length of a module exceeds some maximum value. Ignores comment-only lines.
+Metrics/ModuleLength:
+  Max: 100
+
+# Tries to produce a complexity score that's a measure of the complexity the reader experiences when looking at a
+# method. For that reason it considers `when` nodes as something that doesn't add as much complexity as an `if` or a
+# `&&`. Except if it's one of those special `case`/`when` constructs where there's no expression after `case`. Then
+# the cop treats it as an `if`/`elsif`/`elsif`... and lets all the `when` nodes count. In contrast to
+# CyclomaticComplexity, it considers `else` nodes as adding complexity.
+Metrics/PerceivedComplexity:
+  Max: 7
+
+#################### Lint ################################
+
+# Checks for assignments in the conditions of if/while/until.
+Lint/AssignmentInCondition:
+  AllowSafeAssignment: false
+
+# Checks for interpolated literals.
+#
+# "result is #{10}"
+Lint/LiteralInInterpolation:
+  AutoCorrect: true
+
+# Add new cops added since this was last updated
+Layout/EmptyLinesAroundAttributeAccessor:
+  Enabled: true
+
+Layout/SpaceAroundMethodCallOperator:
+  Enabled: true
+
+Lint/BinaryOperatorWithIdenticalOperands:
+  Enabled: true
+
+Lint/DeprecatedOpenSSLConstant:
+  Enabled: true
+
+Lint/DuplicateElsifCondition:
+  Enabled: true
+
+Lint/DuplicateRescueException:
+  Enabled: true
+
+Lint/EmptyConditionalBody:
+  Enabled: true
+
+Lint/FloatComparison:
+  Enabled: true
+
+Lint/MissingSuper:
+  Enabled: true
+
+Lint/MixedRegexpCaptureTypes:
+  Enabled: true
+
+Lint/OutOfRangeRegexpRef:
+  Enabled: true
+
+Lint/RaiseException:
+  Enabled: true
+
+Lint/SelfAssignment:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true
+
+Lint/TopLevelReturnWithArgument:
+  Enabled: true
+
+Lint/UnreachableLoop:
+  Enabled: true
+
+Style/AccessorGrouping:
+  Enabled: true
+
+Style/ArrayCoercion:
+  Enabled: true
+
+Style/BisectedAttrAccessor:
+  Enabled: true
+
+Style/CaseLikeIf:
+  Enabled: true
+
+Style/ExplicitBlockArgument:
+  Enabled: true
+
+Style/ExponentialNotation:
+  Enabled: true
+
+Style/GlobalStdStream:
+  Enabled: true
+
+Style/HashAsLastArrayItem:
+  Enabled: true
+
+Style/HashEachMethods:
+  Enabled: true
+
+Style/HashLikeCase:
+  Enabled: true
+
+Style/HashTransformKeys:
+  Enabled: true
+
+Style/HashTransformValues:
+  Enabled: true
+
+Style/OptionalBooleanParameter:
+  Enabled: true
+
+Style/RedundantAssignment:
+  Enabled: true
+
+Style/RedundantFetchBlock:
+  Enabled: true
+
+Style/RedundantFileExtensionInRequire:
+  Enabled: true
+
+Style/RedundantRegexpCharacterClass:
+  Enabled: true
+
+Style/RedundantRegexpEscape:
+  Enabled: true
+
+Style/SingleArgumentDig:
+  Enabled: true
+
+Style/SlicingWithRange:
+  Enabled: true
+
+Style/StringConcatenation:
+  Enabled: true
+


### PR DESCRIPTION
Enable to run rubocop with the version 1.x compatible checks.

- rubocop.yml copied from this pr https://github.com/Sage/s1_linter_config/pull/4
- then, [target ruby version](https://docs.rubocop.org/rubocop/configuration.html#setting-the-target-ruby-version) was bumped to 2.6

[list of available rubocop versions](https://github.com/codeclimate/codeclimate-rubocop/branches/all?utf8=%E2%9C%93&query=channel%2Frubocop)