### PR TITLE
rubocop-performance extension supports plugins instead of require

### DIFF
--- a/.rubocop-ruby32-rails5.yml
+++ b/.rubocop-ruby32-rails5.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-performance
   - rubocop-rails
 

--- a/.rubocop-ruby32.yml
+++ b/.rubocop-ruby32.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-performance
 
 AllCops:

--- a/.rubocop-ruby33.yml
+++ b/.rubocop-ruby33.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-performance
 
 AllCops:


### PR DESCRIPTION
`rubocop-performance` extension supports plugin, specify `plugins: rubocop-performance` instead of `require: rubocop-performance`